### PR TITLE
feat(course): ✨ Add direct edit links for creators in learn view

### DIFF
--- a/app/components/course/module-content.tsx
+++ b/app/components/course/module-content.tsx
@@ -4,12 +4,24 @@ import { ContentWithRelations } from "@/app/course/learn/[courseId]/[moduleId]/p
 
 export default function ModuleContent({
   content,
+  isCreator,
+  courseId,
 }: {
   content: ContentWithRelations;
+  isCreator: boolean;
+  courseId: string;
 }) {
   if (content.type === "SLIDE") {
-    return <Slide slide={content.slide!} />;
+    return (
+      <Slide slide={content.slide!} isCreator={isCreator} courseId={courseId} />
+    );
   }
 
-  return <Question question={content.question!} />;
+  return (
+    <Question
+      question={content.question!}
+      isCreator={isCreator}
+      courseId={courseId}
+    />
+  );
 }

--- a/app/components/course/question.tsx
+++ b/app/components/course/question.tsx
@@ -3,6 +3,8 @@
 
 import { useState } from "react";
 import type { Prisma } from "@prisma/client";
+import { Edit } from "lucide-react";
+import Link from "next/link";
 
 type QuestionWithOptions = Prisma.QuestionGetPayload<{
   include: {
@@ -13,9 +15,15 @@ type QuestionWithOptions = Prisma.QuestionGetPayload<{
 
 interface QuestionProps {
   question: QuestionWithOptions;
+  isCreator?: boolean;
+  courseId?: string;
 }
 
-export default function Question({ question }: QuestionProps) {
+export default function Question({
+  question,
+  isCreator,
+  courseId,
+}: QuestionProps) {
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
   const [isSubmitted, setIsSubmitted] = useState(false);
 
@@ -67,10 +75,25 @@ export default function Question({ question }: QuestionProps) {
       <div className="card bg-base-100 shadow-xl border border-base-200">
         <div className="card-body">
           <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6">
-            <h2 className="card-title text-2xl flex-1">
-              {question?.content || "Untitled Question"}
-            </h2>
-            <span className="badge badge-primary self-start">MCQ</span>
+            <div className="flex-1">
+              <div className="flex justify-between items-start gap-3">
+                <h2 className="card-title text-2xl">
+                  {question?.content || "Untitled Question"}
+                </h2>
+                <div className="flex items-center gap-2">
+                  <span className="badge badge-primary">MCQ</span>
+                  {isCreator && courseId && question && (
+                    <Link
+                      href={`/course/edit/${courseId}/question/${question.id}`}
+                      className="btn btn-ghost btn-circle btn-sm"
+                      title="Edit Question"
+                    >
+                      <Edit size={16} />
+                    </Link>
+                  )}
+                </div>
+              </div>
+            </div>
           </div>
 
           <div className="space-y-5">
@@ -78,7 +101,8 @@ export default function Question({ question }: QuestionProps) {
               {question.options.map((option, index) => {
                 const isSelected = selectedOptions.includes(option.id);
                 const isCorrectOption = option.isCorrect;
-                const showResult = isSubmitted && (isSelected || isCorrectOption);
+                const showResult =
+                  isSubmitted && (isSelected || isCorrectOption);
 
                 let optionStyle = "border-base-300 hover:border-primary";
 
@@ -96,22 +120,28 @@ export default function Question({ question }: QuestionProps) {
                   <div
                     key={option.id}
                     className={`p-4 rounded-xl border-2 cursor-pointer transition-all duration-200 ${optionStyle} ${
-                      !isSubmitted ? "hover:shadow-md hover:border-primary/50" : ""
+                      !isSubmitted
+                        ? "hover:shadow-md hover:border-primary/50"
+                        : ""
                     }`}
-                    onClick={() => !isSubmitted && handleOptionChange(option.id)}
+                    onClick={() =>
+                      !isSubmitted && handleOptionChange(option.id)
+                    }
                   >
                     <div className="flex items-start gap-3">
-                      <div className={`flex-shrink-0 mt-0.5 flex items-center justify-center w-6 h-6 rounded-full border-2 ${
-                        isSelected
-                          ? isCorrect && showResult
-                            ? "border-success bg-success text-white"
-                            : isSubmitted
+                      <div
+                        className={`flex-shrink-0 mt-0.5 flex items-center justify-center w-6 h-6 rounded-full border-2 ${
+                          isSelected
+                            ? isCorrect && showResult
+                              ? "border-success bg-success text-white"
+                              : isSubmitted
                               ? "border-error bg-error text-white"
                               : "border-primary bg-primary text-white"
-                          : showResult && isCorrectOption
+                            : showResult && isCorrectOption
                             ? "border-success bg-success text-white"
                             : "border-base-content/30"
-                      }`}>
+                        }`}
+                      >
                         {isSelected && (
                           <svg
                             xmlns="http://www.w3.org/2000/svg"
@@ -119,7 +149,11 @@ export default function Question({ question }: QuestionProps) {
                             viewBox="0 0 20 20"
                             fill="currentColor"
                           >
-                            <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                            <path
+                              fillRule="evenodd"
+                              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                              clipRule="evenodd"
+                            />
                           </svg>
                         )}
                       </div>
@@ -132,7 +166,11 @@ export default function Question({ question }: QuestionProps) {
                             viewBox="0 0 20 20"
                             fill="currentColor"
                           >
-                            <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                            <path
+                              fillRule="evenodd"
+                              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                              clipRule="evenodd"
+                            />
                           </svg>
                           Correct
                         </div>
@@ -144,15 +182,19 @@ export default function Question({ question }: QuestionProps) {
             </div>
 
             {showFeedback && (
-              <div className={`mt-6 p-5 rounded-xl ${
-                isCorrect
-                  ? "bg-success/10 border border-success"
-                  : "bg-error/10 border border-error"
-              }`}>
+              <div
+                className={`mt-6 p-5 rounded-xl ${
+                  isCorrect
+                    ? "bg-success/10 border border-success"
+                    : "bg-error/10 border border-error"
+                }`}
+              >
                 <div className="flex flex-col sm:flex-row items-start gap-4">
-                  <div className={`flex-shrink-0 mt-0.5 flex items-center justify-center w-10 h-10 rounded-full ${
-                    isCorrect ? "bg-success" : "bg-error"
-                  }`}>
+                  <div
+                    className={`flex-shrink-0 mt-0.5 flex items-center justify-center w-10 h-10 rounded-full ${
+                      isCorrect ? "bg-success" : "bg-error"
+                    }`}
+                  >
                     {isCorrect ? (
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
@@ -160,7 +202,11 @@ export default function Question({ question }: QuestionProps) {
                         viewBox="0 0 20 20"
                         fill="currentColor"
                       >
-                        <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                        <path
+                          fillRule="evenodd"
+                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                          clipRule="evenodd"
+                        />
                       </svg>
                     ) : (
                       <svg
@@ -169,19 +215,29 @@ export default function Question({ question }: QuestionProps) {
                         viewBox="0 0 20 20"
                         fill="currentColor"
                       >
-                        <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+                        <path
+                          fillRule="evenodd"
+                          d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                          clipRule="evenodd"
+                        />
                       </svg>
                     )}
                   </div>
                   <div className="flex-1">
-                    <h3 className={`text-lg font-semibold ${
-                      isCorrect ? "text-success" : "text-error"
-                    }`}>
-                      {isCorrect ? "Correct! Well done!" : "Incorrect. Please try again."}
+                    <h3
+                      className={`text-lg font-semibold ${
+                        isCorrect ? "text-success" : "text-error"
+                      }`}
+                    >
+                      {isCorrect
+                        ? "Correct! Well done!"
+                        : "Incorrect. Please try again."}
                     </h3>
                     {question.options[0].explanation && (
                       <div className="mt-3 text-base-content/90">
-                        <p className="font-medium text-base-content/80 mb-1">Explanation:</p>
+                        <p className="font-medium text-base-content/80 mb-1">
+                          Explanation:
+                        </p>
                         <p>{question.options[0].explanation}</p>
                       </div>
                     )}
@@ -198,8 +254,8 @@ export default function Question({ question }: QuestionProps) {
                   isSubmitted
                     ? "btn-disabled"
                     : selectedOptions.length === 0
-                      ? "btn-outline"
-                      : "btn-primary"
+                    ? "btn-outline"
+                    : "btn-primary"
                 }`}
               >
                 {isSubmitted ? "Answer Submitted" : "Submit Answer"}

--- a/app/components/course/slide.tsx
+++ b/app/components/course/slide.tsx
@@ -6,7 +6,8 @@ import "highlight.js/styles/github-dark.css";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import type { Prisma } from "@prisma/client";
-import { BookOpen } from "lucide-react";
+import { BookOpen, Edit } from "lucide-react";
+import Link from "next/link";
 
 type SlideType = Prisma.SlideGetPayload<{
   include: {
@@ -21,7 +22,15 @@ interface CodeProps extends React.HTMLAttributes<HTMLElement> {
   children?: React.ReactNode;
 }
 
-export default function Slide({ slide }: { slide: SlideType }) {
+export default function Slide({
+  slide,
+  isCreator,
+  courseId,
+}: {
+  slide: SlideType;
+  isCreator?: boolean;
+  courseId?: string;
+}) {
   const components: Components = {
     h1: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
       <h1 className="text-4xl font-bold my-6" {...props} />
@@ -73,9 +82,20 @@ export default function Slide({ slide }: { slide: SlideType }) {
 
   return (
     <div className="container mx-auto p-4">
-      <h1 className="text-3xl font-bold mb-6">
-        {slide?.title || "Untitled Slide"}
-      </h1>
+      <div className="flex justify-between items-start mb-6">
+        <h1 className="text-3xl font-bold">
+          {slide?.title || "Untitled Slide"}
+        </h1>
+        {isCreator && courseId && slide && (
+          <Link
+            href={`/course/edit/${courseId}/slide/${slide.id}`}
+            className="btn btn-ghost btn-circle"
+            title="Edit Slide"
+          >
+            <Edit size={20} />
+          </Link>
+        )}
+      </div>
 
       <div className="prose dark:prose-invert max-w-none">
         <ReactMarkdown

--- a/app/course/learn/[courseId]/[moduleId]/learn-module-view.tsx
+++ b/app/course/learn/[courseId]/[moduleId]/learn-module-view.tsx
@@ -22,12 +22,14 @@ export default function LearnModuleView({
   courseId,
   isCompleted: initialIsCompleted,
   nextModuleId,
+  isCreator,
 }: {
   moduleContent: ContentWithRelations[];
   moduleId: string;
   courseId: string;
   isCompleted: boolean;
   nextModuleId: string | null;
+  isCreator: boolean;
 }) {
   const router = useRouter();
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -155,7 +157,13 @@ export default function LearnModuleView({
       </aside>
       <main className="flex-1 overflow-y-auto">
         <div className="w-full min-h-[50vh] flex items-center justify-center p-4">
-          {currentContent && <ModuleContent content={currentContent} />}
+          {currentContent && (
+            <ModuleContent
+              content={currentContent}
+              isCreator={isCreator}
+              courseId={courseId}
+            />
+          )}
         </div>
 
         {totalItems > 1 && (

--- a/app/course/learn/[courseId]/[moduleId]/page.tsx
+++ b/app/course/learn/[courseId]/[moduleId]/page.tsx
@@ -55,6 +55,14 @@ export default async function Page({
     },
   });
 
+  const course = await prisma.course.findUnique({
+    where: { id: courseId },
+    select: { creator: true },
+  });
+
+  const { userId } = await auth();
+  const isCreator = course?.creator === userId;
+
   // Fetch all modules to determine the next module
   const courseModules = await prisma.module.findMany({
     where: {
@@ -127,6 +135,7 @@ export default async function Page({
         courseId={courseId}
         isCompleted={progress.isCompleted}
         nextModuleId={nextModuleId}
+        isCreator={isCreator}
       />
     </div>
   );


### PR DESCRIPTION
This commit introduces a new feature that allows course creators to directly edit slides and questions from the learning interface.

- An "Edit" button is now displayed on slides and questions for the course creator.
- Clicking the button navigates the creator to the corresponding edit page for the specific content.
- This streamlines the content management process by providing a quick access point for edits while reviewing course materials.