### PR TITLE
fix(module-content): 🐛 Add key to ModuleContent for proper re-rendering

### DIFF
--- a/app/course/learn/[courseId]/[moduleId]/learn-module-view.tsx
+++ b/app/course/learn/[courseId]/[moduleId]/learn-module-view.tsx
@@ -159,6 +159,7 @@ export default function LearnModuleView({
         <div className="w-full min-h-[50vh] flex items-center justify-center p-4">
           {currentContent && (
             <ModuleContent
+              key={currentContent.id}
               content={currentContent}
               isCreator={isCreator}
               courseId={courseId}


### PR DESCRIPTION
Adds a 'key' prop to the ModuleContent component within LearnModuleView. This ensures React correctly identifies and re-renders the component when the currentContent changes, preventing potential issues with stale data or incorrect component reuse during navigation between different module contents.