### PR TITLE
feat(learn): 🚀 Implement per-item completion in modules

### DIFF
--- a/app/components/course/module-content.tsx
+++ b/app/components/course/module-content.tsx
@@ -6,10 +6,12 @@ export default function ModuleContent({
   content,
   isCreator,
   courseId,
+  onComplete,
 }: {
   content: ContentWithRelations;
   isCreator: boolean;
   courseId: string;
+  onComplete?: () => void;
 }) {
   if (content.type === "SLIDE") {
     return (
@@ -22,6 +24,7 @@ export default function ModuleContent({
       question={content.question!}
       isCreator={isCreator}
       courseId={courseId}
+      onComplete={onComplete}
     />
   );
 }

--- a/app/components/course/question.tsx
+++ b/app/components/course/question.tsx
@@ -17,12 +17,14 @@ interface QuestionProps {
   question: QuestionWithOptions;
   isCreator?: boolean;
   courseId?: string;
+  onComplete?: () => void;
 }
 
 export default function Question({
   question,
   isCreator,
   courseId,
+  onComplete,
 }: QuestionProps) {
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
   const [isSubmitted, setIsSubmitted] = useState(false);
@@ -54,6 +56,9 @@ export default function Question({
   const handleSubmit = () => {
     setIsSubmitted(true);
     console.log("Selected options:", selectedOptions);
+    if (onComplete) {
+      onComplete();
+    }
   };
 
   const isAnswerCorrect = (): boolean | null => {

--- a/app/course/learn/[courseId]/[moduleId]/learn-module-view.tsx
+++ b/app/course/learn/[courseId]/[moduleId]/learn-module-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import {
   ChevronLeft,
@@ -36,9 +36,34 @@ export default function LearnModuleView({
   const [isCompleted, setIsCompleted] = useState(initialIsCompleted);
   const [isCompleting, setIsCompleting] = useState(false);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [completedItemIds, setCompletedItemIds] = useState<Set<string>>(
+    new Set()
+  );
   const totalItems = moduleContent.length;
   const currentContent = moduleContent[currentIndex];
+  // Determine if the current item is completed
+  const isCurrentItemCompleted =
+    currentContent && completedItemIds.has(currentContent.id);
+
   const isOnLastItem = currentIndex === totalItems - 1;
+  const allItemsCompleted = moduleContent.every((item) =>
+    completedItemIds.has(item.id)
+  );
+
+  const handleMarkAsCompleted = (id: string) => {
+    setCompletedItemIds((prev) => {
+      const newSet = new Set(prev);
+      newSet.add(id);
+      return newSet;
+    });
+  };
+
+  // Auto-complete slides when viewed
+  useEffect(() => {
+    if (currentContent && currentContent.type === "SLIDE") {
+      handleMarkAsCompleted(currentContent.id);
+    }
+  }, [currentContent]);
 
   const goToNext = () => {
     if (currentIndex < totalItems - 1) {
@@ -159,9 +184,11 @@ export default function LearnModuleView({
         <div className="w-full min-h-[50vh] flex items-center justify-center p-4">
           {currentContent && (
             <ModuleContent
+              key={currentContent.id}
               content={currentContent}
               isCreator={isCreator}
               courseId={courseId}
+              onComplete={() => handleMarkAsCompleted(currentContent.id)}
             />
           )}
         </div>
@@ -187,18 +214,20 @@ export default function LearnModuleView({
               </span>
 
               {isOnLastItem && !isCompleted ? (
-                <button
-                  type="button"
-                  className="btn btn-success md:gap-2"
-                  onClick={handleCompleteModule}
-                  disabled={isCompleting}
-                  aria-label="Complete module"
-                >
-                  <Trophy className="w-5 h-5" />
-                  <span className="hidden md:inline">
-                    {isCompleting ? "Completing..." : "Complete Module"}
-                  </span>
-                </button>
+                allItemsCompleted && (
+                  <button
+                    type="button"
+                    className="btn btn-success md:gap-2"
+                    onClick={handleCompleteModule}
+                    disabled={isCompleting}
+                    aria-label="Complete module"
+                  >
+                    <Trophy className="w-5 h-5" />
+                    <span className="hidden md:inline">
+                      {isCompleting ? "Completing..." : "Complete Module"}
+                    </span>
+                  </button>
+                )
               ) : isOnLastItem && isCompleted ? (
                 <button
                   type="button"
@@ -228,7 +257,9 @@ export default function LearnModuleView({
                   type="button"
                   className="btn btn-primary md:gap-2"
                   onClick={goToNext}
-                  disabled={currentIndex === totalItems - 1}
+                  disabled={
+                    currentIndex === totalItems - 1 || !isCurrentItemCompleted
+                  }
                   aria-label="Next slide"
                 >
                   <span className="hidden md:inline">Next</span>


### PR DESCRIPTION
- Introduces a requirement for users to complete each item (slide or question) within a module before proceeding to the next.
- Slides are automatically marked as complete upon viewing.
- Questions are marked as complete upon submitting an answer.
- The "Next" button is disabled until the current item is completed.
- The final "Complete Module" button only becomes active after all items in the module have been completed.
- This ensures a more thorough and engaging learning progression.